### PR TITLE
Export endpoints at top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,19 @@ serve(z, port=8080, name='data.zarr', allowed_origins=["*"])
 
 Chunk compression is an important aspect Zarr, but you shouldn't have to pay for a codec 
 you don't use! Ultimately array compression might not be known until _runtime_, so by
-default `zarr-lite` exports a `registry` that serves to dynamically import (`numcodecs.js`)
-codecs from a CDN. The `registry` is just a JavaScript `Map`, so you can override this default
-behavior (e.g. host your own modules or use your own codecs) by overriding the registry key:
+default `zarr-lite` contains a codec `registry` the dynamically imports (`numcodecs.js`)
+codecs from a CDN. The `registry` is just an ES6 `Map`, and you can override this default
+behavior (e.g. host your own modules or use your own codecs) using `addCodec`.
 
 ```javascript
-import { registry, openArray } from 'zarr-lite';
+import { addCodec, openArray } from 'zarr-lite';
 import MyCustomCodec from './myCustomCodec';
 
 // override CDN codec
-registry.set('blosc', () => MyCustomCodec);
+addCodec('blosc', () => MyCustomCodec);
 
 // add new codec
-registry.set(MyCustomCodec.id, () => MyCustomCodec);
+addCodec(MyCustomCodec.id, () => MyCustomCodec);
 
 const z = await openArray({ store });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manzt/zarr-lite",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manzt/zarr-lite",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A partial Zarr Implementation for reading array chunks.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "url": "https://github.com/manzt/zarr-lite.git"
   },
   "type": "module",
-  "module": "dist/index.js",
+  "module": "index.js",
   "files": [
-    "dist"
+    "*.js"
   ],
   "exports": {
-    ".": "./dist/index.js",
-    "./indexing": "./dist/indexing.js",
-    "./httpStore": "./dist/httpStore.js"
+    ".": "./index.js",
+    "./indexing": "./indexing.js",
+    "./httpStore": "./httpStore.js"
   },
   "scripts": {
-    "build": "rollup --format esm --dir dist src/index.js src/indexing.js src/httpStore.js"
+    "build": "rollup --format esm --dir . src/index.js src/indexing.js src/httpStore.js"
   },
   "keywords": [],
   "author": "Trevor Manz",


### PR DESCRIPTION
I realized that the most recent release in #2 broke some URLs import `zarr-lite` from a CDN. #2 Didn't introduce breaking changes in the source code, but it may have for some due to the importing from the top-level directory of the npm package rather than `dist`. This PR adds a patch release to mimic the original file structure.

Specifically, these examples from @will-moore are working again:

Simplest example https://jsfiddle.net/will_j_moore/tv95ybh8/1/

Using 'omero' channel min/max rendering settings https://jsfiddle.net/will_j_moore/vxa92bnf/77/