### PR TITLE
Use zarrita package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ $ cd zarr-lite && npm install
 $ npm run dev # builds source in watch mode
 ```
 
-You can serve the contents of `dist/` via an http server and test in the browser. For now, I've just been using 
-https://observablehq.com/@manzt/using-zarr-lite to experiment.
+You can serve the contents of `dist/` via an http server and test in the browser. I've just been using 
+https://observablehq.com/@manzt/using-zarr-lite to experiment since most of the library is imported from 
+`zarrita`.
 
 #### Publishing
 

--- a/README.md
+++ b/README.md
@@ -97,3 +97,25 @@ const z = await openArray({ store });
 ```
 
 For more information about the `Codec` interface, checkout [`numcodecs.js`](https://github.com/manzt/numcodecs.js).
+
+
+
+#### Development
+
+```bash
+$ git clone https://github.com/manzt/zarr-lite.git
+$ cd zarr-lite && npm install
+$ npm run dev # builds source in watch mode
+```
+
+You can serve the contents of `dist/` via an http server and test in the browser. For now, I've just been using 
+https://observablehq.com/@manzt/using-zarr-lite to experiment.
+
+#### Publishing
+
+```bash
+$ npm version [<newversion> | major | minor | patch]
+$ npm run build # bundles source & copies README.md + package.json to dist/
+$ cd dist
+$ npm publish
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manzt/zarr-lite",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,128 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@rollup/plugin-node-resolve": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.0.tgz",
+      "integrity": "sha512-8Hrmwjn1pLYjUxcv7U7IPP0qfnzEJWHyHE6CaZ8jbLM+8axaarJRB1jB6JgKTDp5gNga+TpsgX6F8iuvgOerKQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.12.tgz",
+      "integrity": "sha512-ASH8OPHMNlkdjrEdmoILmzFfsJICvhBsFfAum4aKZ/9U4B6M6tTmTPh+f3ttWdD74CEGV5XvXWkbyfSdXaTd7g==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "fsevents": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
     },
     "rollup": {
       "version": "2.34.2",
@@ -21,9 +137,9 @@
       }
     },
     "zarrita": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.1.4.tgz",
-      "integrity": "sha512-ahHxK5uQ6YD4jy2bZlkT1svGIdZTQcQ3I4ji9XljuiK66X3ed1GgtRiHKujlNVgONGoCXVNTkZ51q77pPERUiA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.1.5.tgz",
+      "integrity": "sha512-9m6NKYQYUghzj/CjeGMJeJgFfb4BvKo6yPLE0R6k4l22nEShKxH11qZ2GI7JLtzEPpCnHTdic3KAsynDusbQ3Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "./httpStore": "./httpStore.js"
   },
   "scripts": {
-    "build": "rollup --format esm --dir dist src/index.js src/core.js src/httpStore.js",
-    "postbuild": "cp -r types/* dist"
+    "dev": "rollup -c --watch",
+    "build": "rollup -c",
+    "postbuild": "cp -r types/* dist && cp package.json dist && cp README.md dist"
   },
   "keywords": [
     "zarr",
@@ -31,7 +32,8 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^11.0.0",
     "rollup": "^2.34.1",
-    "zarrita": "^0.1.3"
+    "zarrita": "^0.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manzt/zarr-lite",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A partial Zarr Implementation for reading array chunks.",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,7 @@
+import resolve from '@rollup/plugin-node-resolve';
+
+export default {
+  input: ['src/index.js', 'src/core.js', 'src/httpStore.js'],
+  output: { dir: 'dist', format: 'esm' },
+  plugins: [ resolve() ]
+}

--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,4 @@
-import { ZarrArray } from '../node_modules/zarrita/src/core.js';
+import { ZarrArray } from 'zarrita/core';
 
 import HTTPStore from './httpStore.js';
 import { KeyError } from './errors.js';

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,1 +1,1 @@
-export { KeyError } from '../node_modules/zarrita/src/errors.js';
+export { KeyError } from 'zarrita/lib/errors';

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 export * from './core.js';
 import { ZarrArray } from './core.js';
 
-import { _BasicIndexer, _get_selection, slice } from '../node_modules/zarrita/src/indexing.js';
+import { _BasicIndexer, _get_selection, slice } from 'zarrita/lib/indexing';
 export { slice };
 
 // mutate prototype and add indexing


### PR DESCRIPTION
I added package exports to `zarrita@0.1.5` https://github.com/manzt/zarrita.js/pull/11 which are resolved with `@rollup/plugin-node-resolve'. This PR upgrades `zarrita` and adds some instructions for development.